### PR TITLE
feat(review): modernize the review page UI

### DIFF
--- a/src/app/review/page.tsx
+++ b/src/app/review/page.tsx
@@ -74,8 +74,8 @@ export default async function Page(props: { searchParams: Params }) {
   return isFinish ? (
     <Finish />
   ) : (
-    <div className="flex justify-center flex-col items-center py-8">
+    <main className="mx-auto w-full max-w-3xl px-4 py-8 md:py-12">
       <CardClient noteBox={cardDetailMap} />
-    </div>
+    </main>
   )
 }

--- a/src/components/Finish.tsx
+++ b/src/components/Finish.tsx
@@ -1,17 +1,24 @@
+import { Sparkles } from 'lucide-react'
+
 import GoHome from './GoHome'
 
 export default function Finish() {
   return (
-    <div className="container">
-      <div className="min-h-screen bg-base-200 flex flex-1 justify-center items-center">
-        <div className="text-center">
-          <div className="max-w-md">
-            <h1 className="text-5xl font-bold">Great job!🎉🎉🎉</h1>
-            <p className="py-6">You have finished this project for now.</p>
-            <GoHome />
-          </div>
+    <main className="mx-auto flex w-full max-w-md flex-1 items-center justify-center px-4 py-16 md:py-24">
+      <div className="flex w-full flex-col items-center gap-6 rounded-2xl border border-border/70 bg-card p-10 text-center shadow-xs">
+        <div className="flex size-14 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-500">
+          <Sparkles className="size-7" />
         </div>
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+            All caught up
+          </h1>
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            No cards left to review for now. Great work — come back later.
+          </p>
+        </div>
+        <GoHome />
       </div>
-    </div>
+    </main>
   )
 }

--- a/src/components/schedule/CardsClient.tsx
+++ b/src/components/schedule/CardsClient.tsx
@@ -4,7 +4,6 @@ import type { State } from 'ts-fsrs'
 import { QACard } from '@/components/source'
 import { CardProvider } from '@/context/CardContext'
 
-import { Separator } from '../ui/separator'
 import DSRDisplay from './DSR'
 import RollbackButton from './rollbackButton'
 import ShowAnswerButton from './ShowAnswerButton'
@@ -17,12 +16,23 @@ export default function CardClient({
 }) {
   return (
     <CardProvider noteBox0={noteBox}>
-      <QACard />
-      <Separator className="md:w-[80%] mt-2" />
-      <StatusBar />
-      <ShowAnswerButton />
-      <DSRDisplay />
-      <RollbackButton />
+      <section className="rounded-2xl border border-border/70 bg-card text-card-foreground shadow-xs">
+        <header className="flex items-center justify-between gap-3 border-b border-border/60 px-5 py-3">
+          <StatusBar />
+          <RollbackButton />
+        </header>
+        <div className="px-6 py-10 md:px-10 md:py-14">
+          <QACard />
+        </div>
+      </section>
+
+      <div className="mt-6">
+        <ShowAnswerButton />
+      </div>
+
+      <div className="mt-6 flex justify-center">
+        <DSRDisplay />
+      </div>
     </CardProvider>
   )
 }

--- a/src/components/schedule/DSR.tsx
+++ b/src/components/schedule/DSR.tsx
@@ -19,19 +19,19 @@ export default function DSRDisplay() {
       className="flex items-center gap-3 text-xs tabular-nums text-muted-foreground"
     >
       {items.map(([key, value], i) => (
-        <span key={key} className="flex items-center gap-3">
+        <div key={key} className="flex items-center gap-3">
           {i > 0 && (
             <span aria-hidden className="text-border">
               ·
             </span>
           )}
-          <span className="flex items-center gap-1.5">
+          <div className="flex items-center gap-1.5">
             <dt className="font-medium uppercase tracking-wide text-muted-foreground/80">
               {key}
             </dt>
             <dd className="font-semibold text-foreground/80">{value}</dd>
-          </span>
-        </span>
+          </div>
+        </div>
       ))}
     </dl>
   )

--- a/src/components/schedule/DSR.tsx
+++ b/src/components/schedule/DSR.tsx
@@ -5,11 +5,34 @@ import { useCardContext } from '@/context/CardContext'
 
 export default function DSRDisplay() {
   const { DSR, open, currentType } = useCardContext()
-  return DSR && !open && currentType === State.Review ? (
-    <div className="flex justify-center opacity-15 flex-col text-left mx-auto">
-      <div>{`D : ${DSR.D.toFixed(2)}`}</div>
-      <div>{`S : ${DSR.S}`}</div>
-      <div>{`R : ${DSR.R}`}</div>
-    </div>
-  ) : null
+  if (!DSR || open || currentType !== State.Review) return null
+
+  const items: Array<[string, string]> = [
+    ['D', DSR.D.toFixed(2)],
+    ['S', String(DSR.S)],
+    ['R', DSR.R],
+  ]
+
+  return (
+    <dl
+      aria-label="Card memory state"
+      className="flex items-center gap-3 text-xs tabular-nums text-muted-foreground"
+    >
+      {items.map(([key, value], i) => (
+        <span key={key} className="flex items-center gap-3">
+          {i > 0 && (
+            <span aria-hidden className="text-border">
+              ·
+            </span>
+          )}
+          <span className="flex items-center gap-1.5">
+            <dt className="font-medium uppercase tracking-wide text-muted-foreground/80">
+              {key}
+            </dt>
+            <dd className="font-semibold text-foreground/80">{value}</dd>
+          </span>
+        </span>
+      ))}
+    </dl>
+  )
 }

--- a/src/components/schedule/ShowAnswerButton.tsx
+++ b/src/components/schedule/ShowAnswerButton.tsx
@@ -9,6 +9,17 @@ import { cn } from '@/lib/utils'
 
 import { Button } from '../ui/button'
 
+const GRADE_STYLES = [
+  // Again
+  'bg-rose-600 hover:bg-rose-500 active:bg-rose-700',
+  // Hard
+  'bg-amber-500 hover:bg-amber-400 active:bg-amber-600',
+  // Good
+  'bg-sky-600 hover:bg-sky-500 active:bg-sky-700',
+  // Easy
+  'bg-emerald-600 hover:bg-emerald-500 active:bg-emerald-700',
+] as const
+
 function ShowAnswerButton() {
   const {
     open,
@@ -22,7 +33,6 @@ function ShowAnswerButton() {
 
   const handleKeyPress = useCallback(
     async (event: React.KeyboardEvent<HTMLElement>) => {
-      // Call updateCalc here
       if (!open && event.code === 'Space') {
         setOpen(true)
       } else if (open) {
@@ -43,14 +53,12 @@ function ShowAnswerButton() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [open, handleRollBack, handleSchdule, setOpen]
   )
+
   useEffect(() => {
-    // attach the event listener
     const handleKeyDown = (event: KeyboardEvent) => {
       handleKeyPress(event as unknown as React.KeyboardEvent<HTMLElement>)
     }
     document.addEventListener('keydown', handleKeyDown)
-
-    // remove the event listener
     return () => {
       document.removeEventListener('keydown', handleKeyDown)
     }
@@ -58,56 +66,57 @@ function ShowAnswerButton() {
 
   const note = noteBox[currentType][0]
   if (!note) return null
-  const color = ['bg-red-500', 'bg-orange-500', 'bg-blue-500', 'bg-green-500']
-  const hoverColor = [
-    'hover:bg-red-600',
-    'hover:bg-orange-600',
-    'hover:bg-blue-600',
-    'hover:bg-green-600',
-  ]
-  return !open ? (
-    <Button
-      className="mt-4 tooltip tooltip-bottom w-full md:w-[80%]"
-      onClick={() => {
-        setOpen(true)
-      }}
-      variant={'outline'}
-      title="Press Space to show answer"
-    >
-      Show Answer
-    </Button>
-  ) : (
-    schedule && (
-      <div className="flex justify-center pt-6">
-        {Grades.map((grade: Grade) =>
-          show_diff_message(
-            schedule[grade].card.due,
-            schedule[grade].card.last_review as Date,
-            true
-          )
-        ).map((time: string, index: number) => (
-          <Button
-            key={Rating[(index + 1) as Grade]}
-            className={cn(
-              'btn mx-2 btn-sm md:btn-md tooltip tooltip-bottom bg-orange-500',
-              color[index],
-              hoverColor[index]
-            )}
-            onClick={async () => handleSchdule((index + 1) as Grade)}
-            title={time}
-          >
-            <span>{Rating[(index + 1) as Grade]}</span>
-            <span className="hidden sm:inline">
-              <kbd
-                className={`ml-1 pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100`}
-              >
-                <span className="text-xs">{index + 1}</span>
-              </kbd>
-            </span>
-          </Button>
-        ))}
-      </div>
+
+  if (!open) {
+    return (
+      <Button
+        size="lg"
+        onClick={() => setOpen(true)}
+        className="h-12 w-full gap-3 text-base font-medium"
+      >
+        <span>Show answer</span>
+        <kbd className="pointer-events-none inline-flex h-6 select-none items-center rounded-md border border-primary-foreground/20 bg-primary-foreground/10 px-2 font-mono text-[11px] font-medium uppercase tracking-wide">
+          Space
+        </kbd>
+      </Button>
     )
+  }
+
+  if (!schedule) return null
+
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      {Grades.map((grade: Grade) =>
+        show_diff_message(
+          schedule[grade].card.due,
+          schedule[grade].card.last_review as Date,
+          true
+        )
+      ).map((time: string, index: number) => {
+        const grade = (index + 1) as Grade
+        const label = Rating[grade]
+        return (
+          <button
+            type="button"
+            key={label}
+            onClick={async () => handleSchdule(grade)}
+            title={`${label} · ${time}`}
+            className={cn(
+              'group relative flex flex-col items-center justify-center gap-1 rounded-xl px-4 py-4 text-white shadow-xs transition-[filter,transform,background-color] hover:brightness-110 active:scale-[0.98] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+              GRADE_STYLES[index]
+            )}
+          >
+            <span className="text-sm font-semibold tracking-wide">{label}</span>
+            <span className="text-[11px] font-medium tabular-nums opacity-90">
+              {time}
+            </span>
+            <kbd className="pointer-events-none absolute right-2 top-2 inline-flex h-5 w-5 select-none items-center justify-center rounded bg-white/20 font-mono text-[10px] font-medium text-white">
+              {index + 1}
+            </kbd>
+          </button>
+        )
+      })}
+    </div>
   )
 }
 

--- a/src/components/schedule/StatusBar.tsx
+++ b/src/components/schedule/StatusBar.tsx
@@ -2,41 +2,45 @@
 import { State } from 'ts-fsrs'
 
 import { useCardContext } from '@/context/CardContext'
+import { cn } from '@/lib/utils'
 
-import { Badge } from '../ui/badge'
+const STATES = [
+  { type: State.New, label: 'New', dot: 'bg-sky-500' },
+  { type: State.Learning, label: 'Learning', dot: 'bg-amber-500' },
+  { type: State.Review, label: 'Review', dot: 'bg-emerald-500' },
+] as const
 
 export default function StatusBar() {
   const { noteBox, currentType } = useCardContext()
 
   return (
-    <div className="flex justify-center text-white flex-1">
-      <Badge className="bg-blue-500 hover:bg-blue-500 h-8 my-2 gap-2 mr-2 dark:text-white">
-        {currentType === State.New ? (
-          <span className="underline underline-offset-2">
-            {noteBox[State.New].length}
-          </span>
-        ) : (
-          noteBox[State.New].length
-        )}
-      </Badge>
-      <Badge className="bg-red-500 hover:bg-red-500 h-8 my-2 gap-2 mr-2 dark:text-white">
-        {currentType === State.Learning ? (
-          <span className="underline underline-offset-4">
-            {noteBox[State.Learning].length}
-          </span>
-        ) : (
-          noteBox[State.Learning].length
-        )}
-      </Badge>
-      <Badge className=" bg-green-500  hover:bg-green-500  h-8 my-2 gap-2 mr-2 dark:text-white">
-        {currentType === State.Review ? (
-          <span className="underline underline-offset-4">
-            {noteBox[State.Review].length}
-          </span>
-        ) : (
-          noteBox[State.Review].length
-        )}
-      </Badge>
+    <div className="flex flex-wrap items-center gap-1.5">
+      {STATES.map(({ type, label, dot }) => {
+        const active = currentType === type
+        return (
+          <div
+            key={type}
+            aria-current={active ? 'true' : undefined}
+            className={cn(
+              'inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+              active
+                ? 'border-foreground/15 bg-foreground/5 text-foreground'
+                : 'border-transparent bg-muted text-muted-foreground'
+            )}
+          >
+            <span className={cn('h-1.5 w-1.5 rounded-full', dot)} />
+            <span>{label}</span>
+            <span
+              className={cn(
+                'tabular-nums',
+                active ? 'font-semibold text-foreground' : 'text-foreground/60'
+              )}
+            >
+              {noteBox[type].length}
+            </span>
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/src/components/schedule/rollbackButton.tsx
+++ b/src/components/schedule/rollbackButton.tsx
@@ -18,10 +18,11 @@ export default function RollbackButton() {
       onClick={async () => {
         await handleRollBack()
       }}
+      aria-label="Undo"
       title="Press Ctrl+Z (⌘+Z) to undo"
       className="h-8 gap-1.5 px-2 text-muted-foreground hover:text-foreground"
     >
-      <Undo2 className="size-4" />
+      <Undo2 className="size-4" aria-hidden="true" />
       <span className="hidden text-xs font-medium sm:inline">Undo</span>
     </Button>
   )

--- a/src/components/schedule/rollbackButton.tsx
+++ b/src/components/schedule/rollbackButton.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { Undo2 } from 'lucide-react'
+
 import { useCardContext } from '@/context/CardContext'
 
 import { Button } from '../ui/button'
@@ -7,16 +9,20 @@ import { Button } from '../ui/button'
 export default function RollbackButton() {
   const { rollbackAble, handleRollBack } = useCardContext()
 
-  return rollbackAble ? (
+  if (!rollbackAble) return null
+
+  return (
     <Button
-      className="sm:hidden w-full md:w-[80%] mt-4"
-      variant={'outline'}
+      variant="ghost"
+      size="sm"
       onClick={async () => {
         await handleRollBack()
       }}
-      title="Press Ctrl+Z(⌘+Z) to rollback"
+      title="Press Ctrl+Z (⌘+Z) to undo"
+      className="h-8 gap-1.5 px-2 text-muted-foreground hover:text-foreground"
     >
-      Rollback
+      <Undo2 className="size-4" />
+      <span className="hidden text-xs font-medium sm:inline">Undo</span>
     </Button>
-  ) : null
+  )
 }

--- a/src/components/source/Hitsu.tsx
+++ b/src/components/source/Hitsu.tsx
@@ -21,23 +21,63 @@ export function HitsuAnswer({
   const 発音 = extend.発音 as string | undefined
   const ビデオ = extend.ビデオ as string | undefined
 
+  if (!open) return null
+
   return (
-    open && (
-      <>
-        <div className="flex justify-center items-center text-sm opacity-60">
-          {分類 && <span>{`${分類}`}</span>}
-          {分類 && 品詞 && <span>|</span>}
-          {品詞 && <span>{`${品詞}`}</span>}
+    <div className="mt-8 border-t border-border/60 pt-8">
+      {(分類 || 品詞) && (
+        <div className="mb-4 flex justify-center gap-1.5">
+          {分類 && (
+            <span className="inline-flex items-center rounded-full border border-border/70 bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
+              {分類}
+            </span>
+          )}
+          {品詞 && (
+            <span className="inline-flex items-center rounded-full border border-border/70 bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
+              {品詞}
+            </span>
+          )}
         </div>
-        <div className="pt-4 mx-auto max-w-5xl px-4">
-          <div>意味:{note?.answer}</div>
-          {例文 && <div>例文:{例文}</div>}
-          {例文訳 && <div>例文訳:{例文訳}</div>}
-          {解説 && <div>解説:{解説}</div>}
+      )}
+      <dl className="mx-auto max-w-2xl space-y-3 text-base leading-relaxed text-foreground/80">
+        <Row label="意味" value={note?.answer} emphasize />
+        {例文 && <Row label="例文" value={例文} />}
+        {例文訳 && <Row label="例文訳" value={例文訳} />}
+        {解説 && <Row label="解説" value={解説} />}
+      </dl>
+      {(発音 || ビデオ) && (
+        <div className="mt-6 flex flex-col items-center gap-3">
           {発音 && <Audio url={発音} />}
           {ビデオ && <Video url={ビデオ} />}
         </div>
-      </>
-    )
+      )}
+    </div>
+  )
+}
+
+function Row({
+  label,
+  value,
+  emphasize = false,
+}: {
+  label: string
+  value?: string | null
+  emphasize?: boolean
+}) {
+  return (
+    <div className="grid grid-cols-[4rem_1fr] items-baseline gap-3">
+      <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </dt>
+      <dd
+        className={
+          emphasize
+            ? 'whitespace-pre-wrap break-words text-foreground'
+            : 'whitespace-pre-wrap break-words text-muted-foreground'
+        }
+      >
+        {value}
+      </dd>
+    </div>
   )
 }

--- a/src/components/source/Lingq.tsx
+++ b/src/components/source/Lingq.tsx
@@ -10,6 +10,7 @@ import Audio from '@/components/card/Audio'
 
 import { getLingqToken } from './call/Lingq'
 import { HighlightedWord, MergeTransliteration } from './display/Lingq'
+
 export function Question({ open, note }: { open: boolean; note: TCardDetail }) {
   const extend = note.extend as Partial<Lingq> & {
     lang: string
@@ -43,46 +44,54 @@ export function Question({ open, note }: { open: boolean; note: TCardDetail }) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [note, lang])
+
   return (
-    <div className="item-center">
-      <div className="w-full">
-        <span className="flex justify-center items-center text-2xl">
-          {note.question}
-          {/* <span className="badge">{note.answer}</span> */}
-        </span>
-        <div className="flex justify-center flex-col items-center opacity-60 pt-4">
-          {open && transliteration && (
-            <div> {<MergeTransliteration {...transliteration} />}</div>
-          )}
+    <div className="text-center">
+      <h2 className="break-words text-3xl font-semibold tracking-tight text-foreground md:text-4xl">
+        {note.question}
+      </h2>
+      <div className="mt-4 flex flex-col items-center gap-3 text-muted-foreground">
+        {open && transliteration && (
           <div className="text-sm">
-            {tags?.map((tag) => (
-              <span key={tag} className="badge">
+            <MergeTransliteration {...transliteration} />
+          </div>
+        )}
+        {tags && tags.length > 0 && (
+          <div className="flex flex-wrap justify-center gap-1.5">
+            {tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center rounded-full border border-border/70 bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground"
+              >
                 {tag}
               </span>
             ))}
           </div>
-          {open && words ? (
-            <div className="text-sm pt-2">
-              {words?.map((word) => (
-                <span key={word} className="badge badge-ghost">
-                  {word}
-                </span>
-              ))}
-            </div>
-          ) : null}
-          <div>
-            <HighlightedWord text={fragment} word={note.question} />
+        )}
+        {open && words && words.length > 0 && (
+          <div className="flex flex-wrap justify-center gap-1.5">
+            {words.map((word) => (
+              <span
+                key={word}
+                className="inline-flex items-center rounded-full bg-foreground/5 px-2.5 py-0.5 text-xs font-medium text-foreground/70"
+              >
+                {word}
+              </span>
+            ))}
           </div>
-          {audio && (
-            <Audio
-              url={audio}
-              ref={audioRef}
-              onCanPlay={() => {
-                audioRef.current?.play()
-              }}
-            />
-          )}
+        )}
+        <div className="text-sm leading-relaxed">
+          <HighlightedWord text={fragment} word={note.question} />
         </div>
+        {audio && (
+          <Audio
+            url={audio}
+            ref={audioRef}
+            onCanPlay={() => {
+              audioRef.current?.play()
+            }}
+          />
+        )}
       </div>
     </div>
   )
@@ -91,16 +100,24 @@ export function Question({ open, note }: { open: boolean; note: TCardDetail }) {
 export function Answer({ open, note }: { open: boolean; note: TCardDetail }) {
   const extend = note.extend as Partial<Lingq>
   const hints = extend.hints
-  return open ? (
-    <div className="pt-4 mx-auto max-w-5xl px-4">
-      <ul>
+  if (!open) return null
+  return (
+    <div className="mt-8 border-t border-border/60 pt-8">
+      <ul className="mx-auto max-w-2xl space-y-2">
         {hints?.map((hint) => (
-          <li key={hint.id}>
-            <span className="badge">{hint.locale}</span>
-            {hint.text}
+          <li
+            key={hint.id}
+            className="flex items-start gap-2 text-base leading-relaxed text-muted-foreground"
+          >
+            <span className="mt-0.5 inline-flex items-center rounded-full border border-border/70 bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+              {hint.locale}
+            </span>
+            <span className="flex-1 break-words text-foreground/80">
+              {hint.text}
+            </span>
           </li>
         ))}
       </ul>
     </div>
-  ) : null
+  )
 }

--- a/src/components/source/Lingq.tsx
+++ b/src/components/source/Lingq.tsx
@@ -100,11 +100,11 @@ export function Question({ open, note }: { open: boolean; note: TCardDetail }) {
 export function Answer({ open, note }: { open: boolean; note: TCardDetail }) {
   const extend = note.extend as Partial<Lingq>
   const hints = extend.hints
-  if (!open) return null
+  if (!open || !hints?.length) return null
   return (
     <div className="mt-8 border-t border-border/60 pt-8">
       <ul className="mx-auto max-w-2xl space-y-2">
-        {hints?.map((hint) => (
+        {hints.map((hint) => (
           <li
             key={hint.id}
             className="flex items-start gap-2 text-base leading-relaxed text-muted-foreground"

--- a/src/components/source/default.tsx
+++ b/src/components/source/default.tsx
@@ -4,20 +4,21 @@ import type { TCardDetail } from '@server/services/decks/cards'
 
 export function Question({ note }: { note: TCardDetail }) {
   return (
-    <div className="item-center">
-      <div className="w-full">
-        <span className="flex justify-center items-center text-2xl">
-          {note.question}
-        </span>
-      </div>
+    <div className="text-center">
+      <h2 className="break-words text-3xl font-semibold tracking-tight text-foreground md:text-4xl">
+        {note.question}
+      </h2>
     </div>
   )
 }
 
 export function Answer({ open, note }: { open: boolean; note: TCardDetail }) {
-  return open ? (
-    <div className="pt-4 mx-auto max-w-5xl px-4">
-      <div>{note?.answer}</div>
+  if (!open) return null
+  return (
+    <div className="mt-8 border-t border-border/60 pt-8">
+      <p className="mx-auto max-w-2xl whitespace-pre-wrap break-words text-center text-base leading-relaxed text-muted-foreground md:text-lg">
+        {note?.answer}
+      </p>
     </div>
-  ) : null
+  )
 }


### PR DESCRIPTION
## Summary
- Replace dead daisyUI classes (`bg-base-200`, `tooltip-bottom`, `badge-ghost`, raw `bg-red/blue/green-500`) with semantic shadcn/Tailwind tokens that respect the existing dark-mode CSS variables.
- Wrap the review experience in a refined card surface with a status header, inline rollback affordance, and improved typography across the default / Lingq / Hitsu sources.
- Show Answer / grade controls now expose visible `kbd` hints, due-time labels, and accessible focus rings; the Rollback action is promoted from a mobile-only button to a discoverable icon control.
- Soften the DSR debug strip from `opacity-15` to a labelled metric row, and refresh the Finish state with a Sparkles icon and centered card.

## UX before → after
- **Status pills**: 3 raw colored badges with underline → 3 quiet pills with colored dot + active surface.
- **Show Answer**: outline button with `title` keyboard hint → primary CTA with inline `<kbd>Space</kbd>`.
- **Grade buttons**: 4 unstyled colored buttons → 4 clearly labelled tiles (Rating + due time + numeric `<kbd>`).
- **Finish**: daisyUI `bg-base-200 min-h-screen` block → centered card with Sparkles icon and supporting copy.

## Test plan
- [ ] `pnpm install`
- [ ] `pnpm lint` (no new warnings beyond the pre-existing format/`any` reports)
- [ ] `npx tsc --noEmit` passes
- [ ] Visual smoke test: load `/review` with cards in each State (New / Learning / Review), toggle Show Answer, grade with keyboard 1–4, hit Ctrl/⌘+Z to undo, exhaust the queue to confirm the new Finish view.
- [ ] Toggle dark mode and verify contrast remains ≥ WCAG AA on pills, kbd hints, and DSR metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)