### PR TITLE
fix(review-history): reverse order and start # from 1

### DIFF
--- a/src/components/record/LogTable.tsx
+++ b/src/components/record/LogTable.tsx
@@ -18,6 +18,7 @@ type Props = {
 
 async function LogTable({ logs }: Props) {
   const total_duration = logs.reduce((acc, log) => acc + log.duration, 0)
+  const reversedLogs = logs.slice().reverse()
   return (
     <Table>
       <TableHeader>
@@ -38,9 +39,11 @@ async function LogTable({ logs }: Props) {
         </TableRow>
       </TableHeader>
       <TableBody>
-        {logs.map((log, index) => (
+        {reversedLogs.map((log, index) => (
           <TableRow key={log.id}>
-            <TableCell className="font-medium">{index}</TableCell>
+            <TableCell className="font-medium">
+              {reversedLogs.length - index}
+            </TableCell>
             <TableCell>
               <DateItem date={log.review}></DateItem>
             </TableCell>


### PR DESCRIPTION
## Summary
- Display Review history in reverse chronological order (newest first)
- Number entries starting from 1 (oldest = #1, latest = #N) instead of 0

Addresses [ISH-9](mention://issue/da5bf5b8-339b-4b17-87bc-98970a032ee5).

## Test plan
- [ ] Visit a note detail page with multiple review logs
- [ ] Confirm the newest review now appears at the top of the table
- [ ] Confirm the # column starts at 1 (for the oldest entry at the bottom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)