### PR TITLE
chore(deps): upgrade typescript to 6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "postcss": "^8.5.10",
     "tailwindcss": "^4.2.2",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.2"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,8 +197,8 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
 
 packages:
 
@@ -1969,8 +1969,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -3485,7 +3485,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   uncrypto@0.1.3: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
@@ -13,7 +13,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "downlevelIteration": true,
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
## Summary
- Upgrade `typescript` devDependency from `^5.9.3` → `^6.0.2`
- Bump `tsconfig.json` `target` from `es5` → `ES2022` and remove `downlevelIteration` to address TS 6.0 deprecations (TS5107 / TS5101)

## Why this approach
TypeScript 6.0 deprecates `target: es5` and `downlevelIteration`, requiring either modernization or `ignoreDeprecations: "6.0"` to silence. Since this project is Next.js 16 + React 19 with `noEmit: true` (actual emit handled by SWC/Turbopack), the `target` setting only affects available lib defs and type-level iterator checks — modernizing to `ES2022` is safer and future-proof for TS 7.0.

## Test plan
- [x] `pnpm exec tsc --noEmit` passes cleanly
- [x] `pnpm build` (Next.js 16 turbopack build) passes, including its built-in TypeScript step
- [ ] Pre-existing biome lint warnings/errors remain (unrelated to this upgrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)